### PR TITLE
Add exercise lookup by id

### DIFF
--- a/app/src/main/java/com/example/sporttracker/data/db/dao/ExerciseDao.kt
+++ b/app/src/main/java/com/example/sporttracker/data/db/dao/ExerciseDao.kt
@@ -9,6 +9,9 @@ interface ExerciseDao {
     @Query("SELECT * FROM exercises")
     fun getAllExercises(): Flow<List<Exercise>>
 
+    @Query("SELECT * FROM exercises WHERE id = :id LIMIT 1")
+    fun getExerciseById(id: Int): Flow<Exercise?>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertExercise(exercise: Exercise)
 

--- a/app/src/main/java/com/example/sporttracker/data/repository/ExerciseRepository.kt
+++ b/app/src/main/java/com/example/sporttracker/data/repository/ExerciseRepository.kt
@@ -10,6 +10,9 @@ class ExerciseRepository @Inject constructor(
 ) {
     fun getAllExercises(): Flow<List<Exercise>> = exerciseDao.getAllExercises()
 
+    fun getExerciseById(id: Int): Flow<Exercise?> =
+        exerciseDao.getExerciseById(id)
+
     suspend fun insertExercise(exercise: Exercise) = exerciseDao.insertExercise(exercise)
 
     suspend fun updateExercise(exercise: Exercise) = exerciseDao.updateExercise(exercise)

--- a/app/src/main/java/com/example/sporttracker/presentation/viewmodel/ExerciseViewModel.kt
+++ b/app/src/main/java/com/example/sporttracker/presentation/viewmodel/ExerciseViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.sporttracker.data.model.Exercise
 import com.example.sporttracker.data.repository.ExerciseRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -37,4 +38,7 @@ class ExerciseViewModel @Inject constructor(
             repository.deleteExercise(exercise)
         }
     }
+
+    fun getExerciseById(id: Int): Flow<Exercise?> =
+        repository.getExerciseById(id)
 }


### PR DESCRIPTION
## Summary
- add DAO method for retrieving an Exercise by id
- expose `getExerciseById` through repository and view model

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6852e7b377908333b1d3247dcea35e4b